### PR TITLE
Added: Example of how to turn field data into an id and back again

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ The value returned is an array with the users `id` and `name`, eg:
 
 ```php
 array(
-    'id' => 1
-    'name' => 'Joe Blogs'
+	'id'   => 1
+	'name' => 'Joe Blogs'
 )
 ```
 
@@ -36,11 +36,11 @@ the data.
  * @return array('name' => string, 'id' => int)
  */
 function id_to_user_select_text($value) {
-    $user = get_user_by('id', (int)$value);
-    return array(
-        'name' => $user->display_name,
-        'id' => $user->ID,
-    );
+	$user = get_user_by('id', (int)$value);
+	return array(
+		'name' => $user->display_name,
+		'id'   => $user->ID,
+	);
 }
 
 /**
@@ -49,12 +49,12 @@ function id_to_user_select_text($value) {
  * @return int
  */
 function user_select_text_to_id($value) {
-    return $value['id'];
+	return $value['id'];
 }
 
 $cmb2->add_field( array(
-    // ...snip...
-    'escape_cb' => 'user_select_text_to_id',
-    'sanitization_cb' => 'id_to_user_select_text',
+	// ...snip...
+	'escape_cb'       => 'user_select_text_to_id',
+	'sanitization_cb' => 'id_to_user_select_text',
 ) );
 ```

--- a/README.md
+++ b/README.md
@@ -14,3 +14,47 @@ $cmb2->add_field( array(
 	),
 ) );
 ```
+
+The value returned is an array with the users `id` and `name`, eg:
+
+```php
+array(
+    'id' => 1
+    'name' => 'Joe Blogs'
+)
+```
+
+This will be serialised if saved directly into the database.
+
+If you wish to store the users ID only, you can use `escape_cb` and `sanitization_cb` to transform
+the data.
+
+```php
+/**
+ * Takes the id from the database and returns an array for user_select_text
+ * @param int $value
+ * @return array('name' => string, 'id' => int)
+ */
+function id_to_user_select_text($value) {
+    $user = get_user_by('id', (int)$value);
+    return array(
+        'name' => $user->display_name,
+        'id' => $user->ID,
+    );
+}
+
+/**
+ * Takes the array from user_select_text and returns the id for the database
+ * @param array('name' => string, 'id' => int) $value
+ * @return int
+ */
+function user_select_text_to_id($value) {
+    return $value['id'];
+}
+
+$cmb2->add_field( array(
+    // ...snip...
+    'escape_cb' => 'user_select_text_to_id',
+    'sanitization_cb' => 'id_to_user_select_text',
+) );
+```


### PR DESCRIPTION
Hi there, I hope this is useful.

We wanted to replace an existing user select (which loaded 15k users into a standard dropdown) with CMB2-User-Select. The original select only returned the users id, and so we needed CMB2-User-Select to empulate that behaviour so that we didn't loose existing data.

It took us a little digging around CMB2's main documentation to find out how to do that, so I thought adding it to the README here might others.